### PR TITLE
fix: Rerender ChartPanel and VisualPanel in Dashboard on Server Address Change

### DIFF
--- a/src/views/dashboard/Dashboard.jsx
+++ b/src/views/dashboard/Dashboard.jsx
@@ -11,8 +11,8 @@ function Dashboard() {
   const serverAddress = location.state?.address;
   const dispatch = useDispatch();
   const token = useSelector((state) => state.user.token);
-  const { data, error } = useSocket(serverAddress, token);
   const monitorData = useSelector((state) => state.monitor.data);
+  const { data, error } = useSocket(serverAddress, token);
 
   useEffect(() => {
     if (data) {
@@ -38,7 +38,7 @@ function Dashboard() {
 
   return (
     <div className="grid grid-cols-2 h-screen-minus-header">
-      <ChartPanel data={monitorData} />
+      <ChartPanel initialData={monitorData} />
       <VisualPanel data={monitorData} />
     </div>
   );

--- a/src/views/dashboard/chart/ChartPanel.jsx
+++ b/src/views/dashboard/chart/ChartPanel.jsx
@@ -1,13 +1,28 @@
 import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { memoryConfig } from "@/configs/chartJS/memory";
 import { networkConfig } from "@/configs/chartJS/network";
 import { diskConfig } from "@/configs/chartJS/disk";
 import SystemOverview from "./SystemOverview";
 import BaseChart from "./BaseChart";
 
-function ChartPanel({ data }) {
+function ChartPanel({ initialData }) {
+  const [data, setData] = useState(initialData);
+  const location = useLocation();
+  const serverAddress = location.state?.address;
+
+  useEffect(() => {
+    setData(null);
+  }, [location]);
+
+  useEffect(() => {
+    setData(initialData);
+  }, [initialData]);
+
   return (
-    <div className="flex items-center justify-center">
+    <div className="flex flex-col items-center justify-center">
+      <h2 className="mb-10 text-xl text-white">{serverAddress}</h2>
       <div className="grid grid-cols-9 gap-4 w-5/6 text-center text-white">
         <SystemOverview
           title={"CPU"}
@@ -86,7 +101,7 @@ function ChartPanel({ data }) {
 }
 
 ChartPanel.propTypes = {
-  data: PropTypes.object,
+  initialData: PropTypes.object,
 };
 
 export default ChartPanel;

--- a/src/views/dashboard/visual/VisualPanel.jsx
+++ b/src/views/dashboard/visual/VisualPanel.jsx
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
 import useAnimation from "@/hooks/useAnimation";
 import { handleResize } from "@/utils/threeJS/handlers";
 import {
@@ -18,6 +19,7 @@ import { createBuilding } from "@/utils/threeJS/cpuBuildings";
 import useVisualUpdates from "@/hooks/useVisualUpdates";
 
 function VisualPanel({ data }) {
+  const location = useLocation();
   const sceneRef = useRef(null);
   const mountRef = useRef(null);
   const rendererRef = useRef(null);
@@ -95,7 +97,7 @@ function VisualPanel({ data }) {
         false,
       );
     };
-  }, []);
+  }, [location]);
 
   useVisualUpdates(data, refs);
 


### PR DESCRIPTION
## What is this PR?

This PR introduces dynamic Re-rendering of the ChartPanel and VisualPanel components in the dashboard in response to changes in the server address.

<br>

## Changes / Description

We observed that our dashboard components were not reflecting the latest data upon changing the server address. To enhance user experience and ensure the display of up-to-date information, we implemented a mechanism to detect server address changes and trigger component updates.

<br>

## Details of Changes

- ChartPanel Component: Now, it uses a useEffect hook to reset its data to null whenever the route changes. This is immediately followed by another useEffect that updates the component with new data as soon as it becomes available.
- VisualPanel Component: This component leverages the useLocation hook to detect server address changes and rerenders its main logic accordingly.

<br>

## Reference Documents / Issues

.

<br>

## Screenshots (optional)

.

<br>

## Other Information (optional)

.

<br>
