### PR TITLE
chore: Add responsive design for mobile view under 1000px width

### DIFF
--- a/src/assets/svgIcons.jsx
+++ b/src/assets/svgIcons.jsx
@@ -133,3 +133,20 @@ export const inputEnterIcon = (
     />
   </svg>
 );
+
+export const hamburgerIcon = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="w-8 h-8 text-white"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+    />
+  </svg>
+);

--- a/src/views/dashboard/Dashboard.jsx
+++ b/src/views/dashboard/Dashboard.jsx
@@ -59,7 +59,7 @@ function Dashboard() {
 
   return (
     <main>
-      <div className="grid grid-cols-2 h-screen-minus-header">
+      <div className="mini:flex mini:flex-col-reverse mini:h-fit grid grid-cols-2 h-screen-minus-header">
         <ChartPanel initialData={monitorData} />
 
         <VisualPanel data={monitorData} />

--- a/src/views/dashboard/chart/ChartPanel.jsx
+++ b/src/views/dashboard/chart/ChartPanel.jsx
@@ -21,12 +21,12 @@ function ChartPanel({ initialData }) {
   }, [initialData]);
 
   return (
-    <section className="flex flex-col items-center justify-center">
-      <h2 className="mb-10 text-xl text-white">
+    <section className="flex flex-col items-center justify-center mini:mb-5">
+      <h2 className="mini:my-5  mb-10 text-xl text-white">
         {serverAddress === "guestMode" ? "Guest Mode" : serverAddress}
       </h2>
 
-      <div className="grid grid-cols-9 gap-4 w-5/6 text-center text-white">
+      <div className="grid grid-cols-9 gap-4 w-5/6 text-center text-white mini:flex mini:flex-col">
         <SystemOverview
           title={"CPU"}
           detail1={

--- a/src/views/dashboard/chart/SystemOverview.jsx
+++ b/src/views/dashboard/chart/SystemOverview.jsx
@@ -4,6 +4,7 @@ function SystemOverview({ title, children, detail1, detail2, additionalCss }) {
   const containerClasses = additionalCss
     ? `${additionalCss} rounded-3xl bg-black/25`
     : "rounded-3xl bg-black/25";
+  const detailsCss = `mini:px-1 mini:py-3 mini:bg-transparent mini:font-semibold px-4 py-3 flex-none bg-black rounded-3xl`;
 
   return (
     <div className={containerClasses}>
@@ -12,14 +13,14 @@ function SystemOverview({ title, children, detail1, detail2, additionalCss }) {
 
         {children}
 
-        <div className="py-4 flex gap-2 text-xs">
+        <div className="mini:py-0 py-4 flex gap-2 text-xs">
           <div className="flex-1"></div>
 
-          <div className="px-4 py-3 flex-none bg-black rounded-3xl">
+          <div className={detailsCss}>
             <span>&#9679; {detail1}</span>
           </div>
 
-          <div className="px-4 py-3 flex-none bg-black rounded-3xl">
+          <div className={detailsCss}>
             <span>&#9679; {detail2}</span>
           </div>
 

--- a/src/views/header/Header.jsx
+++ b/src/views/header/Header.jsx
@@ -19,7 +19,9 @@ function Header() {
         className={`flex items-center justify-between h-16 ${backgroundColor}`}
       >
         <Link to="/">
-          <h1 className="mx-3 font-figtree text-white text-3xl">Core City</h1>
+          <h1 className="mx-3 font-figtree text-white text-3xl mini:hidden">
+            Core City
+          </h1>
         </Link>
         {isAuthenticated === null ? (
           ""
@@ -45,7 +47,7 @@ function Header() {
             <AuthenticationButton
               handler={handleSignIn}
               title="Sign in"
-              css="mx-3 w-28 h-10 rounded-md bg-gradient-to-r from-cyan-500 to-blue-500 hover:from-cyan-300 hover:to-blue-300 text-md text-[#0000BA]"
+              css="mx-3 w-28 mini:w-20 h-10 rounded-md bg-gradient-to-r from-cyan-500 to-blue-500 hover:from-cyan-300 hover:to-blue-300 text-md font-medium text-[#0000BA]"
               ariaLabel="Sign in button"
             />
           </div>

--- a/src/views/landing-page/LandingPage.jsx
+++ b/src/views/landing-page/LandingPage.jsx
@@ -1,7 +1,9 @@
 function LandingPage() {
   return (
     <main className="flex items-center justify-center h-screen-minus-header bg-gradient-to-t from-[#FF6915] to-[#0000BA]">
-      <h2 className="font-figtree text-white text-[250px]">Core City</h2>
+      <h2 className="font-figtree text-white text-[250px] mini:text-[60px]">
+        Core City
+      </h2>
     </main>
   );
 }

--- a/src/views/server-list/ServerAddressList.jsx
+++ b/src/views/server-list/ServerAddressList.jsx
@@ -44,11 +44,11 @@ function ServerAddressList() {
 
   return (
     <main className="flex flex-col items-center justify-center h-screen-minus-header">
-      <h2 className="font-figtree items-center h-[100px] text-[80px] text-white">
+      <h2 className="font-figtree items-center h-[100px] mini:h-[70px] text-[80px] text-white mini:text-[50px]">
         Core City
       </h2>
 
-      <p className="mt-5 text-xl text-white">
+      <p className="mt-5 mini:px-5 text-xl mini:text-base text-white mini:text-center">
         {`Plant your server address for monitoring,
         and watch a splendid village grow!`}
       </p>

--- a/src/views/user-menu/UserMenu.jsx
+++ b/src/views/user-menu/UserMenu.jsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSelector } from "react-redux";
 import ModalContent from "./modal/ModalContent";
-import { userIcon } from "@/assets/svgIcons";
+import { userIcon, hamburgerIcon } from "@/assets/svgIcons";
 import { useLocation } from "react-router-dom";
 
 function UserMenu() {
@@ -11,8 +11,19 @@ function UserMenu() {
   );
 
   const [showModal, setShowModal] = useState(false);
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const buttonRef = useRef();
   const location = useLocation();
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   useEffect(() => {
     setShowModal(false);
@@ -30,6 +41,8 @@ function UserMenu() {
     approvalRequestServerList.data.some(
       (server) => server.requestList.length > 0,
     );
+
+  const icon = windowWidth <= 1000 ? hamburgerIcon : userIcon;
 
   return (
     <>
@@ -55,7 +68,7 @@ function UserMenu() {
             <span className="relative inline-flex h-3 w-3 right-2 top-0 bg-[#FF6915] rounded-full"></span>
           </span>
         )}
-        {userIcon}
+        {icon}
       </button>
 
       {showModal &&

--- a/src/views/user-menu/modal/ModalContent.jsx
+++ b/src/views/user-menu/modal/ModalContent.jsx
@@ -15,8 +15,19 @@ function ModalContent({ onClose, triggerRef }) {
   const lastElementRef = useRef();
   const userInfo = useSelector((state) => state.user);
   const [isVisible, setIsVisible] = useState(false);
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
   useLoadApprovalRequestServerList();
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   useEffect(() => {
     firstElementRef.current?.focus();
@@ -41,20 +52,24 @@ function ModalContent({ onClose, triggerRef }) {
     };
   }, [onClose, triggerRef, modalRef, firstElementRef, lastElementRef]);
 
-  const modalClass = `absolute w-1/4 top-16 right-5 bg-black/25 rounded-3xl text-white transition-opacity duration-500 ease-in-out ${
+  const modalClass = `absolute w-1/4 mini:w-3/4 mini:h-screen top-16 mini:top-0 right-5 mini:right-0 bg-black/25 mini:bg-[#1B2024] rounded-3xl mini:rounded-none text-white transition-opacity duration-500 ease-in-out ${
     isVisible ? "opacity-100" : "opacity-0"
   }`;
 
   return (
     <div ref={modalRef} className={modalClass}>
-      <button
-        ref={firstElementRef}
-        className="absolute p-3 top-0 right-0 rounded-full hover:bg-white/20"
-        aria-label="Close user menu button"
-        onClick={onClose}
-      >
-        {closeIcon}
-      </button>
+      {windowWidth <= 1000 ? (
+        ""
+      ) : (
+        <button
+          ref={firstElementRef}
+          className="absolute p-3 top-0 right-0 rounded-full hover:bg-white/20"
+          aria-label="Close user menu button"
+          onClick={onClose}
+        >
+          {closeIcon}
+        </button>
+      )}
 
       <div className="flex justify-center my-5 text-normal">
         {userInfo.email}

--- a/src/views/user-menu/modal/RequestList.jsx
+++ b/src/views/user-menu/modal/RequestList.jsx
@@ -42,7 +42,7 @@ function RequestList() {
           >
             {approvalRequestServerList.data.map((requestServer) => (
               <div
-                className="flex flex-col mt-2 py-3 bg-white/10 text-sm hover:bg-white/25"
+                className="flex flex-col mt-2 py-3 bg-white/10 mini:bg-white/5 text-sm hover:bg-white/25 mini:hover:bg-white/5"
                 key={requestServer.address}
               >
                 <DashboardButton

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,9 @@
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
+    screens: {
+      mini: { max: "1000px" },
+    },
     extend: {
       height: {
         "screen-minus-header": "calc(100vh - 4rem)",


### PR DESCRIPTION
## What is this PR?

This PR introduces responsive CSS adjustments to support mobile views for browser widths below 1000px, aiming to improve the user experience across various devices.

<br>

## Changes / Description

The motivation behind these changes was to ensure that our web application provides a consistent and seamless experience for users on mobile devices. Recognizing that a significant portion of web traffic comes from mobile users, it became imperative to adapt our design to be more responsive to smaller screen sizes.

<br>

## Details of Changes

The changes include a series of CSS modifications that make the layout and elements of our web application more adaptable to screen sizes below 1000px in width. This involved adjusting sizes, margins, and padding of elements, as well as implementing media queries to change the layout dynamically based on the browser width. Potential side effects might include alterations in the layout for screens just above the 1000px threshold, which will require further testing and possible adjustments.

<br>

## Reference Documents / Issues

.

<br>

## Screenshots (optional)

![Screenshot 2024-03-11 at 04 57 13](https://github.com/project-CoreCity/Frontend/assets/35984962/657582dc-913d-47d6-b93e-3b23e3bba67c)
![Screenshot 2024-03-11 at 04 57 28](https://github.com/project-CoreCity/Frontend/assets/35984962/1b98eeaa-2d74-449c-8222-9cfc4c61e099)
![Screenshot 2024-03-11 at 04 57 49](https://github.com/project-CoreCity/Frontend/assets/35984962/2fd284a5-3675-400e-a0d5-937845a48286)
![Screenshot 2024-03-11 at 04 58 17](https://github.com/project-CoreCity/Frontend/assets/35984962/7249127f-2a1c-402e-82c4-0092c864f0b1)
![Screenshot 2024-03-11 at 04 58 28](https://github.com/project-CoreCity/Frontend/assets/35984962/94075ee5-162c-4c29-90af-c97b91dca96e)


<br>

## Other Information (optional)

.

<br>
