### PR TITLE
fix: Adjust renderer pixel ratio for high-density displays

### DIFF
--- a/src/utils/threeJS/initializationThreeJS.js
+++ b/src/utils/threeJS/initializationThreeJS.js
@@ -100,6 +100,7 @@ export const initializeRenderer = (ref) => {
   renderer.setSize(size, size);
   renderer.shadowMap.enabled = true;
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.setPixelRatio(window.devicePixelRatio);
 
   ref.current.appendChild(renderer.domElement);
 


### PR DESCRIPTION
## What is this PR?

This PR addresses the issue where 3D models rendered with Three.js appeared distorted on high-density displays.

<br>

## Changes / Description

I received feedback indicating that 3D models were appearing broken or blurry on devices with high-resolution screens. To resolve this, I decided to adjust the renderer's pixel ratio to match the device's screen density.

<br>

## Details of Changes

- Added renderer.setPixelRatio(window.devicePixelRatio); to the initializeRenderer function. This adjustment ensures the renderer adapts its resolution based on the device's pixel ratio.
- This modification significantly improves the visual quality of 3D models across all devices, particularly enhancing clarity on high-density displays.
- A potential side effect might be a performance decrease on older devices due to the increased rendering resolution. However, this change is expected to significantly improve the user experience on most modern devices.

<br>

## Reference Documents / Issues

[.setPixelRatio](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.setPixelRatio)

<br>

## Screenshots (optional)

Before
<img width="268" alt="Screenshot 2024-03-11 at 05 43 20" src="https://github.com/project-CoreCity/Frontend/assets/35984962/09595b5e-4103-4606-b8c0-ada139c471e1">

After
<img width="287" alt="Screenshot 2024-03-11 at 05 43 38" src="https://github.com/project-CoreCity/Frontend/assets/35984962/7bb7f0c6-33df-4b4d-836e-60118aff7d04">


<br>

## Other Information (optional)

This adjustment lays the groundwork for providing an optimal 3D visualization experience across a wide range of devices with varying display densities. We plan to continue researching additional performance optimization strategies.

<br>
